### PR TITLE
fix: target dest file name must contains the name of the bitsfile before the target name if a folder is provided


### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bits"
-version = "0.2.0"
+version = "0.2.1"
 description = "A tool to maintain a collection of latex bits and insert them into a latex template."
 authors = ["Flavio Grandin <flavio.grandin@gmail.com>"]
 packages = [{ include = "bits", from = "src" }]
@@ -65,7 +65,7 @@ clean = { shell = "rm -rf .coverage .pytest_cache tests/artifacts/* dist && find
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.2.0"
+version = "0.2.1"
 tag_format = "v$version"
 bump_message = "build: version $current_version → $new_version"
 version_files = [

--- a/src/bits/registry/registryfile.py
+++ b/src/bits/registry/registryfile.py
@@ -127,6 +127,7 @@ class RegistryFile(Registry):
             pass
 
         dest: Path = self._resolve_path(data.dest or ".")
+        dest = dest / f'{self._path.stem}-{self.name}.pdf' if dest.suffix == "" else dest
 
         target: Target = Target(template, context, dest, name=name, tags=tags)
         return target


### PR DESCRIPTION
build: version 0.2.0 → 0.2.1
tag to create: v0.2.1
increment detected: PATCH
