### PR TITLE
ci: fixing the bumping version not visible error


### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -14,5 +14,5 @@ runs:
       git config --global user.email "actions@github.com"
       cz bump --yes
       cz changelog
-      git push origin HEAD:${{ github.event.pull_request.head.ref }}
+      git push origin HEAD:dev
       git push --tags

--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -14,5 +14,7 @@ runs:
       git config --global user.email "actions@github.com"
       cz bump --yes
       cz changelog
+      git add .
+      git commit -m "chore: bump version"
       git push origin HEAD:dev
       git push --tags


### PR DESCRIPTION
build: version 0.8.1 → 0.9.0
tag to create: v0.9.0
increment detected: MINOR
