### PR TITLE
Support resolving all bits from registry when query is absent in `blocks`

### DIFF
--- a/src/bits/models/blocks_model.py
+++ b/src/bits/models/blocks_model.py
@@ -5,6 +5,6 @@ from .bits_query_model import BitsQueryModel
 
 class BlocksModel(BaseModel):  # pylint: disable=too-few-public-methods
     registry: str | None = None
-    query: BitsQueryModel
+    query: BitsQueryModel | None = None
     context: dict = {}
     metadata: dict = {}

--- a/src/bits/registry/registryfile.py
+++ b/src/bits/registry/registryfile.py
@@ -137,7 +137,10 @@ class RegistryFile(Registry):
             self._resolve_registry(data.registry) if data.registry else self
         )
 
-        bits: Collection[Bit] = registry.bits.query(**data.query.dict())
+        if data.query:
+            bits: Collection[Bit] = registry.bits.query(**data.query.dict())
+        else:
+            bits: Collection[Bit] = registry.bits
 
         context: dict = self._resolve_context(data.context)
 

--- a/tests/unit/test_registryfile.py
+++ b/tests/unit/test_registryfile.py
@@ -1,0 +1,25 @@
+import unittest
+from pathlib import Path
+from bits.registry.registryfile import RegistryFile
+from bits.block import Block
+
+
+class TestRegistryFile(unittest.TestCase):
+    def setUp(self):
+        self.registry_path = Path("tests/resources/collection.yml")
+        self.registry = RegistryFile(self.registry_path)
+
+    def test_resolve_blocks_without_query(self):
+        blocks_data = {
+            "registry": "tests/resources/collection.yml",
+            "context": {},
+            "metadata": {},
+        }
+        blocks = self.registry._resolve_blocks(blocks_data)
+        self.assertTrue(len(blocks) > 0)
+        for block in blocks:
+            self.assertIsInstance(block, Block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #34

Update `BlocksModel` and `_resolve_blocks` to support resolving all bits from registry when `query` is absent.

* Make `query` field optional in `BlocksModel` in `src/bits/models/blocks_model.py`.
* Update `_resolve_blocks` method in `src/bits/registry/registryfile.py` to include all bits if `query` is absent.
* Add test in `tests/unit/test_registryfile.py` to ensure `blocks` entries without `query` include all bits.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bluephlavio/bits-python/pull/35?shareId=0ecd9f88-a9c0-4283-93ee-83072546aa6b).