### PR TITLE
[codex] render src.default by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,34 @@ See `docs/preview-and-plugins.md` for details and examples.
   ```
 
 - Rendering in target templates:
-  - Standard: `\\VAR{ block.render() }`
-  - Fragments: `\\VAR{ block.render('equation') }`,
+  - String `src`: `\\VAR{ block.render() }`
+  - Mapping `src` with `default`: `\\VAR{ block.render() }` renders the
+    `default` fragment.
+  - Mapping `src` without `default`: call a fragment explicitly, for example
+    `\\VAR{ block.render('equation') }`,
     `\\VAR{ block.render('plot') }`
+  - The core never chooses the first mapping entry automatically.
   - Preview shows all fragments for a bit.
 
 - Programmatic API additions:
   - `Bit.is_multi_fragment`, `Bit.fragment_names`
-  - `Bit.render(part: str | None, **ctx)` (requires `part` for fragments)
-  - `Block.render(part: str | None)` and `Block.fragment(name).render()`
+  - `Bit.render(part: str | None, **ctx)` (`part` is optional only when a
+    fragmented bit defines `default`)
+  - `Block.render(part: str | None)`, `Block.has_fragment(name)`,
+    `Block.render_fragment(name, missing=None)`, and
+    `Block.fragment(name).render()`
+
+- `default` is a technical convention for no-argument rendering. It does not
+  imply a domain role: workspaces can also define fragments such as `solution`,
+  `plot`, `left`, or `right`.
+
+  ```yaml
+  src:
+    default: |
+      Testo ordinario del bit.
+    solution: |
+      Soluzione o svolgimento.
+  ```
 
 - Note: Markdown registries (`.md`) only support single-string `src` and will
   refuse to dump multi-fragment bits.

--- a/docs/multi-fragments.md
+++ b/docs/multi-fragments.md
@@ -25,9 +25,12 @@ bits:
 Rendering in Targets
 --------------------
 
-- Standard bits: `\\VAR{ block.render() }`.
-- Fragmented bits: `\\VAR{ block.render('equation') }`,
-  `\\VAR{ block.render('plot') }`.
+- Standard string-source bits: `\\VAR{ block.render() }`.
+- Fragmented bits with a `default` fragment: `\\VAR{ block.render() }`
+  renders `src.default`.
+- Fragmented bits without `default`: choose a fragment explicitly with
+  `\\VAR{ block.render('equation') }`, `\\VAR{ block.render('plot') }`, and so
+  on. The core never selects the first mapping entry automatically.
 - A layout that uses all fragments of selected bits might look like:
 
 ```latex
@@ -48,9 +51,31 @@ API Additions
 - `Bit.is_multi_fragment: bool`
 - `Bit.fragment_names: list[str]`
 - `Bit.render(part: str | None, **ctx)` — when multi‑fragment, `part` is
-  required to avoid ambiguity.
-- `Block.render(part: str | None, **ctx)` — uses the block context plus optional per‑call overrides.
-- `Block.fragment(name).render(**ctx)` — convenience renderer bound to the block, with per‑call overrides.
+  required unless the bit defines a `default` fragment.
+- `Block.render(part: str | None, **ctx)` — uses the block context plus
+  optional per-call overrides.
+- `Block.has_fragment(name)` — checks for a named fragment without reaching
+  into `Bit` internals.
+- `Block.render_fragment(name, missing=None, **ctx)` — renders a named
+  fragment and returns `missing` when it is absent.
+- `Block.fragment(name).render(**ctx)` — convenience renderer bound to the
+  block, with per-call overrides.
+
+Default Fragment
+----------------
+
+`default` is a technical core convention for the fragment used by
+`render()` with no argument. It does not mean "student text" or any other
+domain-specific role; callers can define fragments such as `solution`, `plot`,
+`left`, or `right` according to their own templates.
+
+```yaml
+src:
+  default: |
+    Testo ordinario del bit.
+  solution: |
+    Soluzione o svolgimento.
+```
 
 Notes
 -----

--- a/src/bits/bit.py
+++ b/src/bits/bit.py
@@ -44,9 +44,7 @@ class Bit(Element):
                     for key, val in self.src.items()
                 }
         except Exception as err:
-            raise TemplateLoadError(
-                f"Unable to load bit source: \n\n{self}\n"
-            ) from err
+            raise TemplateLoadError(f"Unable to load bit source: \n\n{self}\n") from err
 
     def __repr__(self) -> str:
         return f"Bit(src={self.src})"
@@ -76,18 +74,24 @@ class Bit(Element):
             return list(self.src.keys())
         return []
 
+    def has_fragment(self, name: str) -> bool:
+        return name in self._templates
+
     def render(self, part: str | None = None, **kwargs) -> str:
         context: dict = {**self.defaults}
         context.update(**kwargs)
         try:
             if isinstance(self.src, str):
                 return self._template.render(context)
-            # Multi-fragment: require explicit part
+
             if not part:
-                raise TemplateRenderError(
-                    "Bit has multiple fragments; specify 'part' to render one. "
-                    f"Available: {', '.join(self.fragment_names)}"
-                )
+                if self.has_fragment("default"):
+                    part = "default"
+                else:
+                    raise TemplateRenderError(
+                        "Bit has multiple fragments; specify 'part' to render one. "
+                        f"Available: {', '.join(self.fragment_names)}"
+                    )
             if part not in self._templates:
                 raise TemplateRenderError(
                     f"Unknown fragment '{part}'. Available: {', '.join(self.fragment_names)}"

--- a/src/bits/block.py
+++ b/src/bits/block.py
@@ -28,6 +28,16 @@ class Block:
         ctx = {**self.context, **extra}
         return self.bit.render(part=part, **ctx)
 
+    def has_fragment(self, name: str) -> bool:
+        return self.bit.has_fragment(name)
+
+    def render_fragment(
+        self, name: str, *, missing: str | None = None, **extra
+    ) -> str | None:
+        if not self.has_fragment(name):
+            return missing
+        return self.render(name, **extra)
+
     def fragment(self, name: str) -> _BlockFragment:
         return _BlockFragment(self.bit, name, self.context)
 

--- a/tests/resources/default-fragment.yaml
+++ b/tests/resources/default-fragment.yaml
@@ -1,0 +1,17 @@
+targets:
+  - name: default-fragment
+    template: ./templates/minimal.tex.j2
+    dest: ${artifacts}
+    context:
+      title: Default Fragment
+    queries:
+      blocks:
+        - where: { name: With Default Fragment }
+    compose:
+      blocks: { flatten: true, merge: concat, as: blocks }
+
+bits:
+  - name: With Default Fragment
+    src:
+      default: "Student text"
+      solution: "Teacher solution"

--- a/tests/unit/test_multi_fragment_bits.py
+++ b/tests/unit/test_multi_fragment_bits.py
@@ -1,10 +1,20 @@
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from bits.bit import Bit
 from bits.block import Block
 from bits.cli.main import app
+from bits.exceptions import TemplateRenderError
+
+
+def test_bit_render_legacy_default_and_explicit_fragments():
+    assert Bit(src="Legacy").render() == "Legacy"
+
+    bit = Bit(src={"default": "Text", "solution": "Sol"})
+    assert bit.render() == "Text"
+    assert bit.render("solution") == "Sol"
 
 
 def test_bit_render_fragments_simple():
@@ -19,6 +29,28 @@ def test_bit_render_fragments_simple():
     blk = Block(bit, context={})
     assert blk.render("equation") == "x=7"
     assert blk.render("plot") == "Plot: T"
+
+
+def test_bit_render_multifragment_without_default_requires_part():
+    bit = Bit(src={"equation": "E", "plot": "P"})
+
+    with pytest.raises(TemplateRenderError):
+        bit.render()
+
+    assert bit.render("equation") == "E"
+
+
+def test_block_renders_default_explicit_and_checks_fragments():
+    block = Block(Bit(src={"default": "Text", "solution": "Sol"}))
+
+    assert block.render() == "Text"
+    assert block.render("solution") == "Sol"
+    assert block.has_fragment("default") is True
+    assert block.has_fragment("solution") is True
+    assert block.has_fragment("missing") is False
+    assert block.render_fragment("solution") == "Sol"
+    assert block.render_fragment("missing") is None
+    assert block.render_fragment("missing", missing="") == ""
 
 
 def test_yaml_registry_build_with_multi_fragment_and_single(resources, tmp_path):
@@ -65,6 +97,21 @@ bits:
     assert "P: Plot(1,2)" in s
     assert "E: $a + $b = $c" in s
     assert "S: SingleBit" in s
+
+
+def test_yaml_registry_build_uses_default_fragment(resources):
+    runner = CliRunner()
+    reg = resources / "default-fragment.yaml"
+
+    res = runner.invoke(app, ["build", str(reg), "--tex"], prog_name="bits")
+    assert res.exit_code == 0, res.output
+
+    tex = Path("tests/artifacts/default-fragment.tex")
+    assert tex.exists(), f"missing: {tex}"
+
+    rendered = tex.read_text(encoding="utf-8")
+    assert "Student text" in rendered
+    assert "Teacher solution" not in rendered
 
 
 def test_src_mapping_must_not_be_empty(tmp_path):


### PR DESCRIPTION
## Summary

- Render the `default` fragment when a multi-fragment bit is rendered without an explicit part.
- Keep multi-fragment bits without `default` strict: callers must still pass a fragment name.
- Add `Block.has_fragment()` and `Block.render_fragment()` helper APIs for external templates/plugins.
- Document the technical meaning of `default` and add YAML build coverage.

## Validation

- `BITS_CONFIG=tests/resources/.bitsrc poetry run pytest tests/unit/test_multi_fragment_bits.py`
- `poetry run poe test`

## Notes

This does not add `targets.outputs` and does not introduce first-class correction/MCQ/VF logic in the core.