### PR TITLE
feat: introduce targets.outputs for multi-variant rendering

### DIFF
--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -1,0 +1,129 @@
+# Target Outputs
+
+## Motivation
+
+A single logical target — with its resolved queries, compose, and context — often needs to
+produce more than one artifact. For example, an exam might need a student sheet and a
+teacher answer key that draw on the **same** set of bits, in the **same** order, with the
+**same** randomisation seed, but rendered through different templates or with extra context.
+
+The naive solution is to define two separate targets that both extend a base target.
+`outputs` removes that duplication: one target resolves queries once, then renders
+multiple variants from the shared result.
+
+## YAML Schema
+
+```yaml
+targets:
+  - name: worksheet
+    template: ${templates}/student.tex.j2
+    dest: ${artifacts}
+    context:
+      title: Worksheet
+    queries:
+      blocks:
+        - where: { tags: [topic] }
+    compose:
+      blocks: { flatten: true, as: blocks }
+
+    outputs:
+      - name: student          # rendered with the target's own template
+        default: true
+
+      - name: teacher
+        suffix: teacher        # file becomes: worksheet-teacher.pdf/.tex
+        template: ${templates}/teacher.tex.j2
+        context:
+          render_mode: teacher # merged on top of the resolved target context
+```
+
+### `TargetOutputModel` fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `str` | Identifier for this output variant (required) |
+| `template` | `str \| null` | Alternative template path; falls back to the target's template |
+| `dest` | `str \| null` | Alternative destination; falls back to the target's dest |
+| `suffix` | `str \| null` | Appended to the file stem: `<target>-<suffix>.pdf` |
+| `context` | `dict` | Overlay merged on top of the resolved target context |
+| `default` | `bool` | Marks the output used by legacy `bits build` (no `--output` flag) |
+
+At most one output may have `default: true`; loading raises an error otherwise.
+If no output carries `default: true`, the **first** output is used as the default.
+
+## Naming
+
+| Scenario | Result file |
+|---|---|
+| `dest: ./dist` (dir), no suffix | `./dist/worksheet.pdf` |
+| `dest: ./dist` (dir), `suffix: teacher` | `./dist/worksheet-teacher.pdf` |
+| `dest: ./dist/custom.pdf`, `suffix: teacher` | `./dist/custom-teacher.pdf` |
+| output has `dest: ./other` (dir) | `./other/worksheet.pdf` |
+| output has `dest: ./other/out.pdf` | `./other/out.pdf` |
+
+## Context merge
+
+The `context` field of each output is **deep-merged** on top of the fully-resolved target
+context (after queries/compose). Dicts are merged recursively; scalars and lists are
+replaced by the output value.
+
+```yaml
+# Target resolves to:
+context:
+  title: Worksheet
+  answer_policy:
+    seed: 42
+    order: shuffle
+
+# Output overlay:
+outputs:
+  - name: teacher
+    context:
+      render_mode: teacher
+
+# Effective context for the teacher output:
+# title: Worksheet
+# answer_policy: { seed: 42, order: shuffle }
+# render_mode: teacher
+```
+
+## Queries are resolved once
+
+The bits query, compose, picklist, seed, and block ordering are determined by the target
+and **shared** across all outputs. Each output only changes what is rendered, not what is
+selected.
+
+## CLI
+
+```bash
+# Build the default output (or the single artifact if no outputs defined)
+bits build registry.yaml --target worksheet --tex
+
+# Build a specific output variant
+bits build registry.yaml --target worksheet --output teacher --tex
+
+# Build all output variants in one command
+bits build registry.yaml --target worksheet --all-outputs --tex
+bits build registry.yaml --target worksheet --all-outputs --pdf
+bits build registry.yaml --target worksheet --all-outputs --both
+```
+
+Error cases:
+
+- `--output NAME` on a target with no `outputs` → clear error, non-zero exit.
+- `--output MISSING` (name not found in outputs) → clear error, non-zero exit.
+- `--all-outputs` on a target with no `outputs` → behaves like a normal build (no error).
+
+## Relation to `extends`
+
+`extends` and `outputs` solve different problems:
+
+| | `extends` | `outputs` |
+|---|---|---|
+| Use case | Logical variant of a target (different topic, profile, course) | Multiple artifacts from the same logical target |
+| Query resolution | Each derived target resolves its own queries | Shared — resolved once for the parent target |
+| Result | Independent targets queryable by name | Sub-variants of one target, not independently queryable |
+
+Use `extends` when the derived target has different bits, a different query, or
+represents a conceptually different document. Use `outputs` when you want the same
+document rendered through different templates or with extra context keys.

--- a/src/bits/bit.py
+++ b/src/bits/bit.py
@@ -44,9 +44,7 @@ class Bit(Element):
                     for key, val in self.src.items()
                 }
         except Exception as err:
-            raise TemplateLoadError(
-                f"Unable to load bit source: \n\n{self}\n"
-            ) from err
+            raise TemplateLoadError(f"Unable to load bit source: \n\n{self}\n") from err
 
     def __repr__(self) -> str:
         return f"Bit(src={self.src})"

--- a/src/bits/cli/helpers.py
+++ b/src/bits/cli/helpers.py
@@ -277,6 +277,8 @@ def initialize_registry(
     intermediates_dir: Path | None = None,
     keep_intermediates: str = "none",
     unique_strategy: str | None = None,
+    output_name: str | None = None,
+    all_outputs: bool = False,
 ):
     """
     Initialize a registry from a path and render its targets.
@@ -324,6 +326,8 @@ def initialize_registry(
                 intermediates_dir=intermediates_dir,
                 keep_intermediates=keep_intermediates,
                 unique_strategy=unique_strategy,
+                output_name=output_name,
+                all_outputs=all_outputs,
             )
             console.print("[bold green]Render complete.[/bold green]")
             print_render_summary(registry, console)
@@ -377,6 +381,8 @@ def watch_for_changes(
     intermediates_dir: Path | None = None,
     keep_intermediates: str = "none",
     unique_strategy: str | None = None,
+    output_name: str | None = None,
+    all_outputs: bool = False,
     loop: bool = True,
 ):
     """
@@ -432,6 +438,8 @@ def watch_for_changes(
                 intermediates_dir=intermediates_dir,
                 keep_intermediates=keep_intermediates,
                 unique_strategy=unique_strategy,
+                output_name=output_name,
+                all_outputs=all_outputs,
             )
 
             console.print("[bold green]Re-render complete.[/bold green]")

--- a/src/bits/cli/main.py
+++ b/src/bits/cli/main.py
@@ -80,6 +80,7 @@ def common(
     # Ensure env-var provided config is merged even if the module was imported
     # before the environment variable was set (e.g., in tests).
     import os
+
     try:
         cfg = os.environ.get("BITS_CONFIG")
         if cfg:
@@ -113,6 +114,16 @@ def render(
         False,
         "--no-plugins",
         help="Disable loading Jinja plugins declared in .bitsrc",
+    ),
+    output: Optional[str] = typer.Option(
+        None,
+        "--output",
+        help="Build a specific output variant by name (requires --target)",
+    ),
+    all_outputs: bool = typer.Option(
+        False,
+        "--all-outputs",
+        help="Build all output variants defined on the target(s)",
     ),
 ):
     console.print("[bold green]Starting build process...[/bold green]")
@@ -149,21 +160,22 @@ def render(
                 break
         if tgt is None:
             raise typer.BadParameter(f"Target not found: {sel}")
-        console.rule("[bold]Build Started (single target)")
-        tex_code = tgt.render_tex_code()
-        if do_tex or do_both:
-            from ..helpers import write as _write
-
-            _write(tex_code, tgt.dest.with_suffix(".tex"))
-        if do_pdf or do_both:
-            Renderer.render(
-                tex_code,
-                tgt.dest,
-                output_tex=False,
-                build_dir=build_dir,
-                intermediates_dir=intermediates_dir,
-                keep_intermediates=keep_intermediates,
+        if output and not tgt._outputs:  # pylint: disable=protected-access
+            raise typer.BadParameter(
+                f"Target '{sel}' has no outputs defined;"
+                " --output requires outputs to be configured"
             )
+        console.rule("[bold]Build Started (single target)")
+        tgt.render(
+            pdf=do_pdf,
+            tex=do_tex,
+            both=do_both,
+            build_dir=build_dir,
+            intermediates_dir=intermediates_dir,
+            keep_intermediates=keep_intermediates,
+            output_name=output,
+            all_outputs=all_outputs,
+        )
         console.rule("[bold]Build Completed")
         return
 
@@ -180,6 +192,8 @@ def render(
         intermediates_dir=intermediates_dir,
         keep_intermediates=keep_intermediates,
         unique_strategy=unique,
+        output_name=output,
+        all_outputs=all_outputs,
     )
 
     if watch:
@@ -195,6 +209,8 @@ def render(
             intermediates_dir=intermediates_dir,
             keep_intermediates=keep_intermediates,
             unique_strategy=unique,
+            output_name=output,
+            all_outputs=all_outputs,
         )
 
 

--- a/src/bits/config.py
+++ b/src/bits/config.py
@@ -33,6 +33,7 @@ except Exception:  # pragma: no cover - environment dependent
 
 config = configparser.ConfigParser(interpolation=ExtendedInterpolation())
 
+
 def _to_string(val: Any) -> str:
     if isinstance(val, bool):
         return "true" if val else "false"
@@ -149,7 +150,9 @@ def _minimal_toml_parse(text: str) -> Dict[str, Any]:  # pragma: no cover
             return items
         if v.lower() in ("true", "false"):
             return v.lower() == "true"
-        if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+        if (v.startswith('"') and v.endswith('"')) or (
+            v.startswith("'") and v.endswith("'")
+        ):
             return v[1:-1]
         # number fallback or bare string
         try:

--- a/src/bits/env.py
+++ b/src/bits/env.py
@@ -125,7 +125,10 @@ class EnvironmentFactory:
                     if name.startswith("_") or name == "register":
                         continue
                     func = getattr(module, name)
-                    if callable(func) and getattr(func, "__module__", None) == module.__name__:
+                    if (
+                        callable(func)
+                        and getattr(func, "__module__", None) == module.__name__
+                    ):
                         # Heuristic: treat functions ending in "_filter" as
                         # providing the implementation for a shorter filter
                         # name without the suffix (e.g. "floor_filter" ->
@@ -193,7 +196,9 @@ class EnvironmentFactory:
                 else []
             )
             plugin_key = f"plugins:{int(cls._plugins_enabled)}|{','.join(plugin_list)}"
-            extras_key = f"filters:{','.join(filter_list)}|macros:{','.join(macro_list)}"
+            extras_key = (
+                f"filters:{','.join(filter_list)}|macros:{','.join(macro_list)}"
+            )
         except Exception:
             plugin_key = f"plugins:{int(cls._plugins_enabled)}"
             extras_key = ""

--- a/src/bits/models/__init__.py
+++ b/src/bits/models/__init__.py
@@ -4,7 +4,7 @@ from .blocks_model import BlocksModel
 from .constant_model import ConstantModel
 from .constants_model import ConstantsModel
 from .registry_model import RegistryDataModel
-from .target_model import TargetModel
+from .target_model import TargetModel, TargetOutputModel
 from .constants_query_model import WhereConstantsModel
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
     "SelectModel",
     "BlocksModel",
     "TargetModel",
+    "TargetOutputModel",
     "ConstantModel",
     "ConstantsModel",
     "BitModel",

--- a/src/bits/models/target_model.py
+++ b/src/bits/models/target_model.py
@@ -1,4 +1,13 @@
-from pydantic import BaseModel  # pylint: disable=no-name-in-module
+from pydantic import BaseModel, validator  # pylint: disable=no-name-in-module
+
+
+class TargetOutputModel(BaseModel):  # pylint: disable=too-few-public-methods
+    name: str
+    template: str | None = None
+    dest: str | None = None
+    suffix: str | None = None
+    context: dict = {}
+    default: bool = False
 
 
 class TargetModel(BaseModel):  # pylint: disable=too-few-public-methods
@@ -16,7 +25,22 @@ class TargetModel(BaseModel):  # pylint: disable=too-few-public-methods
     # Defaults to deep; validated at runtime by resolver for allowed values.
     merge: dict = {}
     # Optional inheritance mechanism: this target extends one or more base targets
-    # Accepts: string (single), list of strings, possibly cross-file refs: "path/file.yml::Name"
+    # Accepts: string (single), list of strings, or cross-file ref "file.yml::Name"
     extends: str | list[str] | None = None
     # Optional path-based overrides applied after merge (on queries/context/compose)
     overrides: list[dict] = []
+    # Optional rendering variants: each output shares the resolved context/queries
+    # but may use a different template, dest, suffix, or context overlay.
+    outputs: list[TargetOutputModel] = []
+
+    @validator("outputs", always=True)
+    @classmethod
+    def _validate_outputs(cls, outputs, values):  # pylint: disable=no-self-argument
+        defaults = [o for o in outputs if o.default]
+        if len(defaults) > 1:
+            name = values.get("name")
+            raise ValueError(
+                f"Target '{name}': multiple outputs have default=True;"
+                " at most one is allowed"
+            )
+        return outputs

--- a/src/bits/registry/registry.py
+++ b/src/bits/registry/registry.py
@@ -63,6 +63,8 @@ class Registry(ABC):
         intermediates_dir=None,
         keep_intermediates: str = "none",
         unique_strategy: str | None = None,
+        output_name: str | None = None,
+        all_outputs: bool = False,
     ) -> None:
         with self._load_lock:
             for target in self._targets:
@@ -75,6 +77,8 @@ class Registry(ABC):
                     intermediates_dir=intermediates_dir,
                     keep_intermediates=keep_intermediates,
                     unique_strategy=unique_strategy,
+                    output_name=output_name,
+                    all_outputs=all_outputs,
                 )
 
     def add_dep(self, registry: Registry) -> None:

--- a/src/bits/registry/registryfile.py
+++ b/src/bits/registry/registryfile.py
@@ -116,7 +116,11 @@ class RegistryFile(Registry):
             try:
                 presets = getattr(bit, "presets", []) or []
                 # Drop any user-defined preset named 'default' (case-sensitive)
-                filtered = [p for p in presets if p.get("name") != "default" and p.get("id") != "default"]
+                filtered = [
+                    p
+                    for p in presets
+                    if p.get("name") != "default" and p.get("id") != "default"
+                ]
                 if len(filtered) != len(presets):
                     warnings.warn(
                         "User-defined preset named 'default' is ignored; the tool creates it automatically.",
@@ -162,6 +166,7 @@ class RegistryFile(Registry):
                 context=merged_spec.get("context") or {},
                 queries=merged_spec.get("queries") or {},
                 compose=merged_spec.get("compose") or {},
+                outputs=target_model.outputs,
             )
             target: Target = self._resolve_target(final_tm)
             target.tags.extend(common_tags)
@@ -329,7 +334,9 @@ class RegistryFile(Registry):
                                 base_merged.pop(path, None)
                             elif op == "clear":
                                 base_merged[path] = (
-                                    {} if isinstance(base_merged.get(path), dict) else []
+                                    {}
+                                    if isinstance(base_merged.get(path), dict)
+                                    else []
                                 )
                             elif op in ("set", "replace"):
                                 base_merged[path] = copy.deepcopy(value)
@@ -337,7 +344,9 @@ class RegistryFile(Registry):
                                 base = base_merged.get(
                                     path, {} if isinstance(value, dict) else []
                                 )
-                                base_merged[path] = self._deep_merge_extends(base, value)
+                                base_merged[path] = self._deep_merge_extends(
+                                    base, value
+                                )
                             else:
                                 raise ValueError(f"Unknown override op: {op}")
                             continue
@@ -385,7 +394,9 @@ class RegistryFile(Registry):
                             if path.startswith("queries."):
                                 self._apply_path_clear(qmap, path)
                             elif path.startswith("context."):
-                                self._apply_path_clear_plain(cmap, path[len("context.") :])
+                                self._apply_path_clear_plain(
+                                    cmap, path[len("context.") :]
+                                )
                             elif path.startswith("compose."):
                                 self._apply_path_clear_plain(
                                     compmap, path[len("compose.") :]
@@ -469,9 +480,7 @@ class RegistryFile(Registry):
                     if path.startswith("queries."):
                         self._remove_path_override(qmap, path)
                     elif path.startswith("context."):
-                        self._remove_path_override_plain(
-                            cmap, path[len("context.") :]
-                        )
+                        self._remove_path_override_plain(cmap, path[len("context.") :])
                     elif path.startswith("compose."):
                         self._remove_path_override_plain(
                             compmap, path[len("compose.") :]
@@ -697,8 +706,16 @@ class RegistryFile(Registry):
 
         # Read optional merge policy
         merge_policy = preset.get("merge") or {}
-        mp_ctx = merge_policy.get("context", "deep") if isinstance(merge_policy, dict) else "deep"
-        mp_q = merge_policy.get("queries", "deep") if isinstance(merge_policy, dict) else "deep"
+        mp_ctx = (
+            merge_policy.get("context", "deep")
+            if isinstance(merge_policy, dict)
+            else "deep"
+        )
+        mp_q = (
+            merge_policy.get("queries", "deep")
+            if isinstance(merge_policy, dict)
+            else "deep"
+        )
         if mp_ctx not in ("deep", "replace"):
             raise ValueError(f"Invalid preset merge value for 'context': {mp_ctx}")
         if mp_q not in ("deep", "replace"):
@@ -728,7 +745,9 @@ class RegistryFile(Registry):
             q_merged = copy.deepcopy(pqueries)
         else:
             # maps deep-merge, lists replace
-            q_merged = self._deep_merge(q_base, pqueries) if (q_base or pqueries) else {}
+            q_merged = (
+                self._deep_merge(q_base, pqueries) if (q_base or pqueries) else {}
+            )
 
         # Apply overrides (path,value,op) on merged queries before resolving
         overrides = preset.get("overrides") or []
@@ -971,7 +990,9 @@ class RegistryFile(Registry):
                 if idx is not None:
                     target_list = cur[key]
                     index = int(idx) - 1
-                    if not isinstance(target_list, list) or not (0 <= index < len(target_list)):
+                    if not isinstance(target_list, list) or not (
+                        0 <= index < len(target_list)
+                    ):
                         warnings.warn(
                             f"Remove override list index out of range (no-op): {path}"
                         )
@@ -1015,7 +1036,9 @@ class RegistryFile(Registry):
                 if idx is not None:
                     target_list = cur[key]
                     index = int(idx) - 1
-                    if not isinstance(target_list, list) or not (0 <= index < len(target_list)):
+                    if not isinstance(target_list, list) or not (
+                        0 <= index < len(target_list)
+                    ):
                         warnings.warn(
                             f"Remove override list index out of range (no-op): {path}"
                         )
@@ -1285,6 +1308,27 @@ class RegistryFile(Registry):
         # This preserves stable, readable naming and aligns with tests.
 
         target: Target = Target(template, context, dest, name=name, tags=tags)
+
+        # Resolve and attach output specs (each shares the already-resolved context)
+        resolved_outputs = []
+        for out_model in data.outputs:
+            out_tpl = self._resolve_template(
+                out_model.template or data.template or config.get("DEFAULT", "template")
+            )
+            out_dest = self._resolve_path(out_model.dest) if out_model.dest else None
+            out_context = self._deep_merge(context, out_model.context)
+            resolved_outputs.append(
+                {
+                    "name": out_model.name,
+                    "template": out_tpl,
+                    "dest": out_dest,
+                    "suffix": out_model.suffix,
+                    "context": out_context,
+                    "default": out_model.default,
+                }
+            )
+        target._outputs = resolved_outputs  # pylint: disable=protected-access
+
         return target
 
     def _resolve_and_compose_queries(self, queries: dict, compose_cfg: dict) -> dict:

--- a/src/bits/target.py
+++ b/src/bits/target.py
@@ -1,3 +1,5 @@
+import datetime as _dt
+import uuid
 from pathlib import Path
 from typing import List
 
@@ -32,6 +34,9 @@ class Target(Element):
             raise ValueError("Target destination must be a pdf file")
 
         self._last_rendered_hash = None
+        # Resolved output specs, populated by RegistryFile after construction.
+        # Each entry: {name, template, context, dest (Path|None), suffix, default}
+        self._outputs: list[dict] = []
 
     def __str__(self) -> str:
         return f"Target: {self.name or self.id}"
@@ -62,29 +67,49 @@ class Target(Element):
         tex_code: str = self.template.render(**self.context)
         return tex_code
 
-    def render(
+    def get_output(self, name: str) -> dict | None:
+        for o in self._outputs:
+            if o["name"] == name:
+                return o
+        return None
+
+    def _get_default_output(self) -> dict | None:
+        for o in self._outputs:
+            if o["default"]:
+                return o
+        return self._outputs[0] if self._outputs else None
+
+    def _compute_output_dest(self, output: dict) -> Path:
+        if output["dest"] is not None:
+            d = output["dest"]
+            if d.suffix == "":
+                stem = self.dest.stem
+                if output["suffix"]:
+                    return d / f"{stem}-{output['suffix']}.pdf"
+                return d / f"{stem}.pdf"
+            return d
+        base = self.dest
+        if output["suffix"]:
+            return base.parent / f"{base.stem}-{output['suffix']}{base.suffix}"
+        return base
+
+    def _render_one(
         self,
-        output_tex: bool = False,
+        template: Template,
+        context: dict,
+        dest: Path,
+        do_tex: bool,
+        do_pdf: bool,
         *,
-        pdf: bool | None = None,
-        tex: bool | None = None,
-        both: bool = False,
         build_dir: Path | None = None,
         intermediates_dir: Path | None = None,
         keep_intermediates: str = "none",
         unique_strategy: str | None = None,
     ) -> None:
-        tex_code: str = self.render_tex_code()
-        # Determine modes
-        do_pdf = bool(both or (pdf is True and not output_tex))
-        do_tex = bool(output_tex or tex or both)
+        tex_code = template.render(**context)
 
-        # Compute final destination (supports unique naming)
-        final_dest = self.dest
+        final_dest = dest
         if unique_strategy in ("uuid", "timestamped"):
-            import uuid
-            import datetime as _dt
-
             stem = final_dest.stem
             if unique_strategy == "uuid":
                 suffix = uuid.uuid4().hex[:8]
@@ -103,4 +128,73 @@ class Target(Element):
                 build_dir=build_dir,
                 intermediates_dir=intermediates_dir,
                 keep_intermediates=keep_intermediates,
+            )
+
+    def render(
+        self,
+        output_tex: bool = False,
+        *,
+        pdf: bool | None = None,
+        tex: bool | None = None,
+        both: bool = False,
+        build_dir: Path | None = None,
+        intermediates_dir: Path | None = None,
+        keep_intermediates: str = "none",
+        unique_strategy: str | None = None,
+        output_name: str | None = None,
+        all_outputs: bool = False,
+    ) -> None:
+        do_pdf = bool(both or (pdf is True and not output_tex))
+        do_tex = bool(output_tex or tex or both)
+
+        render_kwargs = dict(
+            build_dir=build_dir,
+            intermediates_dir=intermediates_dir,
+            keep_intermediates=keep_intermediates,
+            unique_strategy=unique_strategy,
+        )
+
+        if self._outputs:
+            if all_outputs:
+                for out in self._outputs:
+                    self._render_one(
+                        out["template"],
+                        out["context"],
+                        self._compute_output_dest(out),
+                        do_tex,
+                        do_pdf,
+                        **render_kwargs,
+                    )
+            else:
+                if output_name is not None:
+                    out = self.get_output(output_name)
+                    if out is None:
+                        available = [o["name"] for o in self._outputs]
+                        raise ValueError(
+                            f"Output '{output_name}' not found in target"
+                            f" '{self.name}'. Available: {available}"
+                        )
+                else:
+                    out = self._get_default_output()
+                self._render_one(
+                    out["template"],
+                    out["context"],
+                    self._compute_output_dest(out),
+                    do_tex,
+                    do_pdf,
+                    **render_kwargs,
+                )
+        else:
+            if output_name is not None:
+                raise ValueError(
+                    f"Target '{self.name}' has no outputs defined;"
+                    " --output requires outputs to be configured"
+                )
+            self._render_one(
+                self.template,
+                self.context,
+                self.dest,
+                do_tex,
+                do_pdf,
+                **render_kwargs,
             )

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -169,3 +169,81 @@ def test_cli_build_pdf_presets(resources):
             assert expected_pdf.exists()
         else:
             pytest.skip("PDF not generated in local env")
+
+
+# ---------------------------------------------------------------------------
+# Target outputs CLI tests
+# ---------------------------------------------------------------------------
+
+
+def test_cli_build_output_specific(resources):
+    """--output NAME builds only the named output variant."""
+    runner = CliRunner()
+    path = resources / "targets-outputs.yaml"
+    result = runner.invoke(
+        app,
+        ["build", str(path), "--target", "multi-output", "--output", "key", "--tex"],
+        prog_name="bits",
+    )
+    if result.exit_code != 0:
+        print("CLI output:\n", result.output)
+    assert result.exit_code == 0
+
+    artifacts_dir = Path(config.get("variables", "artifacts"))
+    key_tex = artifacts_dir / "multi-output-key.tex"
+    assert key_tex.exists(), f"Expected {key_tex} to exist"
+    assert "Answer Key" in key_tex.read_text()
+
+
+def test_cli_build_all_outputs(resources):
+    """--all-outputs builds every output variant for the target."""
+    runner = CliRunner()
+    path = resources / "targets-outputs.yaml"
+    result = runner.invoke(
+        app,
+        ["build", str(path), "--target", "multi-output", "--all-outputs", "--tex"],
+        prog_name="bits",
+    )
+    if result.exit_code != 0:
+        print("CLI output:\n", result.output)
+    assert result.exit_code == 0
+
+    artifacts_dir = Path(config.get("variables", "artifacts"))
+    student_tex = artifacts_dir / "multi-output.tex"
+    key_tex = artifacts_dir / "multi-output-key.tex"
+    assert student_tex.exists(), f"Expected {student_tex}"
+    assert key_tex.exists(), f"Expected {key_tex}"
+
+
+def test_cli_build_output_on_no_outputs_target(resources):
+    """--output on a target with no outputs must exit with an error."""
+    runner = CliRunner()
+    path = resources / "targets-outputs.yaml"
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            str(path),
+            "--target",
+            "no-outputs",
+            "--output",
+            "student",
+            "--tex",
+        ],
+        prog_name="bits",
+    )
+    assert result.exit_code != 0
+
+
+def test_cli_build_legacy_target_unchanged(resources):
+    """Targets without outputs continue to work exactly as before."""
+    runner = CliRunner()
+    path = resources / "targets-outputs.yaml"
+    result = runner.invoke(
+        app,
+        ["build", str(path), "--target", "no-outputs", "--tex"],
+        prog_name="bits",
+    )
+    if result.exit_code != 0:
+        print("CLI output:\n", result.output)
+    assert result.exit_code == 0

--- a/tests/e2e/test_preview.py
+++ b/tests/e2e/test_preview.py
@@ -65,7 +65,7 @@ def test_preview_single_bit_colon_syntax(resources):
     runner = CliRunner()
     bitsfile = resources / "bits-presets.yaml"
     outdir = Path(config.get("preview", "out_dir", fallback="tests/artifacts/preview"))
-    spec = f"{bitsfile}:\"Mass of the Sun\":default"
+    spec = f'{bitsfile}:"Mass of the Sun":default'
     res = runner.invoke(app, ["preview", spec, "--tex"], prog_name="bits")
     assert res.exit_code == 0
     expected_name = f"{bitsfile.stem}__mass-of-the-sun__p-default.tex"

--- a/tests/resources/plugins/auto_filters.py
+++ b/tests/resources/plugins/auto_filters.py
@@ -7,4 +7,3 @@ def add(a, b):
 
 
 helper = "not a filter"
-

--- a/tests/resources/plugins/auto_filters_for_macros.py
+++ b/tests/resources/plugins/auto_filters_for_macros.py
@@ -1,3 +1,2 @@
 def double_filter(x):
     return x * 2
-

--- a/tests/resources/plugins/auto_filters_suffix.py
+++ b/tests/resources/plugins/auto_filters_suffix.py
@@ -4,4 +4,3 @@ def floor_filter(value):
 
 def ceil_filter(value):
     return int(value // 1 + (value % 1 > 0))
-

--- a/tests/resources/plugins/default_filters.py
+++ b/tests/resources/plugins/default_filters.py
@@ -55,4 +55,3 @@ def register(env):
     env.filters["render"] = render_filter
     env.filters["enumerate"] = enumerate_filter
     env.filters["show"] = show_filter
-

--- a/tests/resources/targets-outputs.yaml
+++ b/tests/resources/targets-outputs.yaml
@@ -1,0 +1,60 @@
+targets:
+  - name: multi-output
+    template: ${templates}/outputs-student.tex.j2
+    dest: ${artifacts}
+    context:
+      title: Output Test
+    outputs:
+      - name: student
+      - name: key
+        suffix: key
+        template: ${templates}/outputs-key.tex.j2
+        context:
+          render_mode: key
+
+  - name: default-explicit
+    template: ${templates}/outputs-student.tex.j2
+    dest: ${artifacts}
+    context:
+      title: Default Explicit Test
+    outputs:
+      - name: student
+      - name: key
+        suffix: key
+        default: true
+        template: ${templates}/outputs-key.tex.j2
+        context:
+          render_mode: key
+
+  - name: no-outputs
+    template: ${templates}/minimal.tex.j2
+    dest: ${artifacts}
+    context:
+      title: No Outputs Legacy
+    queries:
+      blocks:
+        - where: { tags: [output-test] }
+    compose:
+      blocks: { flatten: true, as: blocks }
+
+  - name: deep-merge-output
+    template: ${templates}/outputs-student.tex.j2
+    dest: ${artifacts}
+    context:
+      title: Deep Merge Test
+      nested:
+        base_key: base_value
+        shared_key: from_base
+    outputs:
+      - name: variant
+        suffix: variant
+        context:
+          nested:
+            shared_key: from_output
+            output_key: output_value
+
+bits:
+  - name: OutputBit
+    tags: [output-test]
+    src: |
+      Output test content.

--- a/tests/resources/templates/outputs-key.tex.j2
+++ b/tests/resources/templates/outputs-key.tex.j2
@@ -1,0 +1,10 @@
+\documentclass{article}
+\begin{document}
+\section*{Answer Key}
+mode: \VAR{ render_mode or "student" }
+\begin{enumerate}
+\BLOCK{ for block in (blocks or []) }
+  \item \VAR{ block.render() }
+\BLOCK{ endfor }
+\end{enumerate}
+\end{document}

--- a/tests/resources/templates/outputs-student.tex.j2
+++ b/tests/resources/templates/outputs-student.tex.j2
@@ -1,0 +1,10 @@
+\documentclass{article}
+\begin{document}
+\section*{\VAR{ title or "Document" }}
+mode: \VAR{ render_mode or "student" }
+\begin{enumerate}
+\BLOCK{ for block in (blocks or []) }
+  \item \VAR{ block.render() }
+\BLOCK{ endfor }
+\end{enumerate}
+\end{document}

--- a/tests/unit/test_block_render_overrides.py
+++ b/tests/unit/test_block_render_overrides.py
@@ -23,4 +23,3 @@ def test_block_fragment_render_allows_per_call_overrides():
 
     # Per-call kwargs override fragment context
     assert frag.render(label="Z") == "Z"
-

--- a/tests/unit/test_config_toml.py
+++ b/tests/unit/test_config_toml.py
@@ -7,7 +7,7 @@ from bits.config import config, load_config_file
 
 def test_load_toml_plugins_and_booleans(tmp_path):
     plugin = (Path("tests/resources/plugins/math_filters.py").resolve()).as_posix()
-    toml = f'''
+    toml = f"""
 [variables]
 templates = "tests/resources/templates"
 artifacts = "tests/artifacts"
@@ -18,7 +18,7 @@ plugins = ["{plugin}"]
 [output]
 pdf = true
 tex = false
-'''
+"""
     cfg = tmp_path / ".bits.toml"
     cfg.write_text(toml)
 
@@ -37,4 +37,3 @@ tex = false
     # Booleans should be available via getboolean
     assert config.getboolean("output", "pdf") is True
     assert config.getboolean("output", "tex") is False
-

--- a/tests/unit/test_jinja_auto_filters_macros.py
+++ b/tests/unit/test_jinja_auto_filters_macros.py
@@ -56,12 +56,8 @@ def test_auto_macro_files_register_macros_as_globals():
 
 
 def test_macros_can_use_custom_filters_from_filter_files():
-    filt_path = Path(
-        "tests/resources/plugins/auto_filters_for_macros.py"
-    ).resolve()
-    macro_path = Path(
-        "tests/resources/templates/macros_with_filter.tex.j2"
-    ).resolve()
+    filt_path = Path("tests/resources/plugins/auto_filters_for_macros.py").resolve()
+    macro_path = Path("tests/resources/templates/macros_with_filter.tex.j2").resolve()
     _set_jinja_option("filter_files", str(filt_path))
     _set_jinja_option("macro_files", str(macro_path))
     EnvironmentFactory.enable_plugins(True)

--- a/tests/unit/test_jinja_plugins_parsing.py
+++ b/tests/unit/test_jinja_plugins_parsing.py
@@ -60,4 +60,3 @@ def test_plugins_parsing_list_literal():
         Path(p1).expanduser().as_posix(),
         Path(p2).expanduser().as_posix(),
     ]
-

--- a/tests/unit/test_merge_policy_and_overrides.py
+++ b/tests/unit/test_merge_policy_and_overrides.py
@@ -53,4 +53,3 @@ def test_preset_merge_queries_replace():
     # Should reference the G constant (not c), i.e., symbol $G$
     assert "$G$" in tex
     assert "$c$" not in tex
-

--- a/tests/unit/test_target_outputs.py
+++ b/tests/unit/test_target_outputs.py
@@ -1,0 +1,232 @@
+"""Unit tests for target outputs feature (targets.outputs rendering variants)."""
+
+from pathlib import Path
+
+import pytest
+
+from bits.models.target_model import TargetModel, TargetOutputModel
+from bits.registry import RegistryFactory
+from bits.registry.registryfile import RegistryFile
+
+
+FIXTURE = Path("tests/resources/targets-outputs.yaml").resolve()
+
+
+def _get_target(name: str):
+    reg: RegistryFile = RegistryFactory.get(FIXTURE)
+    for t in reg.targets:
+        if t.name == name:
+            return t
+    raise AssertionError(f"Target not found: {name}")
+
+
+# ---------------------------------------------------------------------------
+# 1. Legacy target without outputs
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_target_has_no_outputs():
+    tgt = _get_target("no-outputs")
+    assert tgt._outputs == []
+
+
+def test_legacy_target_renders_normally():
+    tgt = _get_target("no-outputs")
+    tex = tgt.render_tex_code()
+    assert "No Outputs Legacy" in tex
+
+
+# ---------------------------------------------------------------------------
+# 2. Target with outputs — implicit default (first output)
+# ---------------------------------------------------------------------------
+
+
+def test_multi_output_has_two_outputs():
+    tgt = _get_target("multi-output")
+    assert len(tgt._outputs) == 2
+    assert tgt._outputs[0]["name"] == "student"
+    assert tgt._outputs[1]["name"] == "key"
+
+
+def test_multi_output_default_is_first():
+    tgt = _get_target("multi-output")
+    default = tgt._get_default_output()
+    assert default is not None
+    assert default["name"] == "student"
+
+
+def test_multi_output_render_tex_code_uses_base():
+    """render_tex_code() always returns base template for backward compat."""
+    tgt = _get_target("multi-output")
+    tex = tgt.render_tex_code()
+    # Base template is outputs-student.tex.j2 which prints render_mode or "student"
+    assert "student" in tex
+
+
+# ---------------------------------------------------------------------------
+# 3. Explicit default output
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_default_output_is_key():
+    tgt = _get_target("default-explicit")
+    default = tgt._get_default_output()
+    assert default is not None
+    assert default["name"] == "key"
+
+
+# ---------------------------------------------------------------------------
+# 4. get_output lookup
+# ---------------------------------------------------------------------------
+
+
+def test_get_output_returns_correct_spec():
+    tgt = _get_target("multi-output")
+    out = tgt.get_output("key")
+    assert out is not None
+    assert out["name"] == "key"
+    assert out["suffix"] == "key"
+
+
+def test_get_output_missing_returns_none():
+    tgt = _get_target("multi-output")
+    assert tgt.get_output("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# 5 & 6. Dest computation
+# ---------------------------------------------------------------------------
+
+
+def test_output_dest_with_suffix():
+    tgt = _get_target("multi-output")
+    out = tgt.get_output("key")
+    dest = tgt._compute_output_dest(out)
+    assert dest.stem.endswith("-key")
+    assert dest.suffix == ".pdf"
+    assert dest.name == "multi-output-key.pdf"
+
+
+def test_output_dest_without_suffix():
+    tgt = _get_target("multi-output")
+    out = tgt.get_output("student")
+    dest = tgt._compute_output_dest(out)
+    assert dest == tgt.dest
+    assert dest.name == "multi-output.pdf"
+
+
+# ---------------------------------------------------------------------------
+# 7. Context overlay
+# ---------------------------------------------------------------------------
+
+
+def test_output_context_overlay():
+    tgt = _get_target("multi-output")
+    out = tgt.get_output("key")
+    assert out["context"].get("render_mode") == "key"
+    assert out["context"].get("title") == "Output Test"
+
+
+def test_student_output_has_no_render_mode():
+    tgt = _get_target("multi-output")
+    out = tgt.get_output("student")
+    assert "render_mode" not in out["context"]
+
+
+# ---------------------------------------------------------------------------
+# 8. Context overlay deep merge
+# ---------------------------------------------------------------------------
+
+
+def test_output_context_deep_merge():
+    tgt = _get_target("deep-merge-output")
+    out = tgt.get_output("variant")
+    assert out is not None
+    nested = out["context"]["nested"]
+    # base_key preserved from parent context
+    assert nested["base_key"] == "base_value"
+    # shared_key overridden by output context
+    assert nested["shared_key"] == "from_output"
+    # output_key added by output context
+    assert nested["output_key"] == "output_value"
+
+
+# ---------------------------------------------------------------------------
+# 9. Validation: multiple defaults raise ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_defaults_raises():
+    with pytest.raises(ValueError, match="multiple outputs have default=True"):
+        TargetModel(
+            name="bad",
+            outputs=[
+                TargetOutputModel(name="a", default=True),
+                TargetOutputModel(name="b", default=True),
+            ],
+        )
+
+
+# ---------------------------------------------------------------------------
+# 10. render() with unknown output_name raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_render_unknown_output_name_raises(tmp_path):
+    tgt = _get_target("multi-output")
+    with pytest.raises(ValueError, match="not found"):
+        tgt.render(tex=True, output_name="nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# 11. render() with output_name on target without outputs raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_render_output_name_on_no_outputs_raises(tmp_path):
+    tgt = _get_target("no-outputs")
+    with pytest.raises(ValueError, match="has no outputs defined"):
+        tgt.render(tex=True, output_name="anything")
+
+
+# ---------------------------------------------------------------------------
+# 12. Tex rendering: all_outputs produces files for each output
+# ---------------------------------------------------------------------------
+
+
+def test_render_all_outputs_tex(tmp_path):
+    tgt = _get_target("multi-output")
+    tgt.render(tex=True, all_outputs=True)
+    # student output: multi-output.tex
+    student_tex = tgt.dest.with_suffix(".tex")
+    # key output: multi-output-key.tex
+    key_dest = tgt._compute_output_dest(tgt.get_output("key"))
+    key_tex = key_dest.with_suffix(".tex")
+
+    assert student_tex.exists(), f"Expected {student_tex} to exist"
+    assert key_tex.exists(), f"Expected {key_tex} to exist"
+
+    # Verify content differs per template
+    student_content = student_tex.read_text()
+    key_content = key_tex.read_text()
+    assert "Answer Key" not in student_content
+    assert "Answer Key" in key_content
+
+
+def test_render_specific_output_tex(tmp_path):
+    tgt = _get_target("multi-output")
+    tgt.render(tex=True, output_name="key")
+    key_dest = tgt._compute_output_dest(tgt.get_output("key"))
+    key_tex = key_dest.with_suffix(".tex")
+    assert key_tex.exists()
+    assert "Answer Key" in key_tex.read_text()
+
+
+def test_render_default_output_tex(tmp_path):
+    tgt = _get_target("multi-output")
+    tgt.render(tex=True)
+    student_tex = tgt.dest.with_suffix(".tex")
+    assert student_tex.exists()
+    content = student_tex.read_text()
+    # student template shows "student" mode, no "Answer Key"
+    assert "Answer Key" not in content

--- a/tests/unit/test_target_remove.py
+++ b/tests/unit/test_target_remove.py
@@ -33,4 +33,3 @@ def test_remove_out_of_range_is_noop():
     assert tex.find("Q2") != -1
     assert tex.find("Q3") != -1
     assert tex.find("Q1") < tex.find("Q2") < tex.find("Q3")
-


### PR DESCRIPTION
## Summary

- Adds `TargetOutputModel` Pydantic model with fields: `name`, `template`, `dest`, `suffix`, `context`, `default`
- Adds `outputs: list[TargetOutputModel] = []` to `TargetModel`, with validator that forbids multiple `default: true`
- `Target` now stores pre-resolved output specs; `render()` accepts `output_name=` and `all_outputs=` kwargs
- Registry and helpers propagate the new kwargs through the build pipeline
- CLI `bits build` gains `--output NAME` and `--all-outputs` flags
- 19 new unit tests + 4 new e2e CLI tests; 101 tests total pass
- `docs/outputs.md` documents schema, naming semantics, context merge, and CLI usage

## No-goals

- No MCQ/VF/corrector logic in core
- No changes to `bits-workspace`
- Full backward compatibility: targets without `outputs` are unaffected

## Test plan

- [x] `poetry run pytest --tb=short -q` → 101 passed
- [x] `poetry run poe lint` → clean
- [x] Legacy targets continue to work unchanged
- [x] `--output NAME` selects a specific variant
- [x] `--all-outputs` renders all variants
- [x] `--output` on target without outputs → clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)